### PR TITLE
Add cave_air to the default pass-through list

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,6 +7,7 @@ pass-through:
 - large_fern
 - dead_bush
 - vine
+- cave_air
 descend-speed: 5
 model:
   base:


### PR DESCRIPTION
so that the carpet doesn't surprisingly stop working in nether ravines and other places where cave_air is.